### PR TITLE
Add sTSLA Redemption APIs and Platform Price Endpoint

### DIFF
--- a/backend/api/src/market/controllers/market.controller.ts
+++ b/backend/api/src/market/controllers/market.controller.ts
@@ -132,4 +132,15 @@ export class MarketController {
       toDate,
     );
   }
+
+  @ApiOperation({ summary: 'Get current platform sTSLA price' })
+  @ApiResponse({
+    status: 200,
+    description: 'Current sTSLA price',
+    type: Number,
+  })
+  @Get('price/sTSLA/current')
+  async getCurrentSTeslaPrice(): Promise<number> {
+    return this.priceService.getCurrentSTeslaPrice();
+  }
 }

--- a/backend/api/src/market/controllers/redemption.controller.ts
+++ b/backend/api/src/market/controllers/redemption.controller.ts
@@ -1,0 +1,70 @@
+import { Controller, Post, Body, Get, Param } from '@nestjs/common';
+import { RedemptionService } from '../services/redemption.service';
+import { RedemptionHistory } from '../entities/redemption-history.entity';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiBody,
+} from '@nestjs/swagger';
+
+@ApiTags('redemption')
+@Controller('redemption')
+export class RedemptionController {
+  constructor(private readonly redemptionService: RedemptionService) {}
+
+  @ApiOperation({ summary: 'Redeem sTSLA for the user' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        userAddress: {
+          type: 'string',
+          example: 'HN7cABqLq46Es1jh92dQQisAq662SmxELLLsHHe4YWrH',
+        },
+        amount: { type: 'number', example: 5.0 },
+        price: { type: 'number', example: 750.25 },
+        txId: { type: 'string', example: '5G9s...abc' },
+      },
+      required: ['userAddress', 'amount', 'price', 'txId'],
+    },
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Redemption recorded',
+    type: RedemptionHistory,
+  })
+  @Post()
+  async redeemSTesla(
+    @Body('userAddress') userAddress: string,
+    @Body('amount') amount: number,
+    @Body('price') price: number,
+    @Body('txId') txId: string,
+  ): Promise<RedemptionHistory> {
+    return this.redemptionService.redeemSTesla(
+      userAddress,
+      amount,
+      price,
+      txId,
+    );
+  }
+
+  @ApiOperation({ summary: 'Get redemption history for a user' })
+  @ApiParam({
+    name: 'userAddress',
+    description: 'User wallet address',
+    example: 'HN7cABqLq46Es1jh92dQQisAq662SmxELLLsHHe4YWrH',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Redemption history retrieved',
+    type: [RedemptionHistory],
+  })
+  @Get(':userAddress/history')
+  async getRedemptionHistory(
+    @Param('userAddress') userAddress: string,
+  ): Promise<RedemptionHistory[]> {
+    return this.redemptionService.getRedemptionHistory(userAddress);
+  }
+}

--- a/backend/api/src/market/entities/redemption-history.entity.ts
+++ b/backend/api/src/market/entities/redemption-history.entity.ts
@@ -1,0 +1,42 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+import { ApiProperty } from '@nestjs/swagger';
+
+@Entity('redemption_history')
+@Index(['userAddress'])
+export class RedemptionHistory {
+  @ApiProperty({ description: 'Unique identifier', example: 1 })
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ApiProperty({
+    description: 'User wallet address',
+    example: 'HN7cABqLq46Es1jh92dQQisAq662SmxELLLsHHe4YWrH',
+  })
+  @Column({ type: 'varchar', length: 44 })
+  userAddress: string;
+
+  @ApiProperty({ description: 'Amount of sTSLA redeemed', example: 5.0 })
+  @Column({ type: 'decimal', precision: 18, scale: 8 })
+  amount: number;
+
+  @ApiProperty({ description: 'Redemption price per sTSLA', example: 750.25 })
+  @Column({ type: 'decimal', precision: 18, scale: 8 })
+  price: number;
+
+  @ApiProperty({ description: 'Transaction ID', example: '5G9s...abc' })
+  @Column({ type: 'varchar', length: 100 })
+  txId: string;
+
+  @ApiProperty({
+    description: 'Timestamp of the redemption',
+    example: '2025-05-14T10:30:00.000Z',
+  })
+  @CreateDateColumn()
+  timestamp: Date;
+}

--- a/backend/api/src/market/market.module.ts
+++ b/backend/api/src/market/market.module.ts
@@ -6,14 +6,21 @@ import { PriceService } from './services/price.service';
 import { CollateralService } from './services/collateral.service';
 import { MarketController } from './controllers/market.controller';
 import { BlockchainModule } from '../blockchain/blockchain.module';
+import { RedemptionHistory } from './entities/redemption-history.entity';
+import { RedemptionService } from './services/redemption.service';
+import { RedemptionController } from './controllers/redemption.controller';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([PriceHistory, CollateralRatio]),
+    TypeOrmModule.forFeature([
+      PriceHistory,
+      CollateralRatio,
+      RedemptionHistory,
+    ]),
     BlockchainModule,
   ],
-  providers: [PriceService, CollateralService],
-  controllers: [MarketController],
-  exports: [PriceService, CollateralService],
+  providers: [PriceService, CollateralService, RedemptionService],
+  controllers: [MarketController, RedemptionController],
+  exports: [PriceService, CollateralService, RedemptionService],
 })
 export class MarketModule {}

--- a/backend/api/src/market/services/price.service.ts
+++ b/backend/api/src/market/services/price.service.ts
@@ -68,4 +68,9 @@ export class PriceService {
       this.logger.error(`Error updating sTSLA price: ${error.message}`);
     }
   }
+
+  async getCurrentSTeslaPrice(): Promise<number> {
+    const latest = await this.getLatestPrice('sTSLA');
+    return latest?.price ?? 0;
+  }
 }

--- a/backend/api/src/market/services/redemption.service.ts
+++ b/backend/api/src/market/services/redemption.service.ts
@@ -1,0 +1,43 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { RedemptionHistory } from '../entities/redemption-history.entity';
+
+@Injectable()
+export class RedemptionService {
+  private readonly logger = new Logger(RedemptionService.name);
+
+  constructor(
+    @InjectRepository(RedemptionHistory)
+    private readonly redemptionHistoryRepository: Repository<RedemptionHistory>,
+  ) {}
+
+  async redeemSTesla(
+    userAddress: string,
+    amount: number,
+    price: number,
+    txId: string,
+  ): Promise<RedemptionHistory> {
+    // TODO: Add blockchain interaction for actual redemption
+    const redemption = this.redemptionHistoryRepository.create({
+      userAddress,
+      amount,
+      price,
+      txId,
+    });
+    await this.redemptionHistoryRepository.save(redemption);
+    this.logger.log(
+      `User ${userAddress} redeemed ${amount} sTSLA at ${price} (tx: ${txId})`,
+    );
+    return redemption;
+  }
+
+  async getRedemptionHistory(
+    userAddress: string,
+  ): Promise<RedemptionHistory[]> {
+    return this.redemptionHistoryRepository.find({
+      where: { userAddress },
+      order: { timestamp: 'DESC' },
+    });
+  }
+}


### PR DESCRIPTION
## Summary
This PR introduces new backend features for sTSLA redemption, redemption history tracking, and exposes the current platform sTSLA price.

## Key Changes
- **RedemptionHistory Entity**: Persists sTSLA redemption events.
- **RedemptionService**: Handles sTSLA redemption logic and user redemption history retrieval.
- **RedemptionController**: Provides endpoints to:
  - Redeem sTSLA (`POST /redemption`)
  - Fetch a user's redemption history (`GET /redemption/:userAddress/history`)
- **MarketModule Registration**: Registers the new entity, service, and controller.
- **Indexing**: Adds an index on `userAddress` for efficient redemption history queries.
- **PriceService Extension**: Adds a method to fetch the current platform sTSLA price.
- **MarketController Endpoint**: Adds `GET /market/price/sTSLA/current` to fetch the current sTSLA price.

## Note
Blockchain interaction for actual sTSLA burning is stubbed and should be implemented in the service.
